### PR TITLE
EP-Übersicht mit Editor-Button versehen

### DIFF
--- a/lib/ExtensionPoint/pages/docs.php
+++ b/lib/ExtensionPoint/pages/docs.php
@@ -45,10 +45,20 @@ if (count($all)) {
         }
         $content .= '</nav>';
     } else {
+        
+        $editor = rex_editor::factory();
+        $editButton = null === $editor->getName()
+            ? null
+            : ' <a href="" class="btn btn-info btn-xs"><i class="fa fa-edit"></i> '.$editor->getName().'</a>';
+
         $toc = [];
         $extensionPoints = ExtensionPoint::getByPackage($requestIndex);
         foreach ($extensionPoints as $extensionPoint) {
             $toc[] = '<a href="#' . $extensionPoint->getName() . '">' . $extensionPoint->getName() . '</a>';
+
+            $button = null === $editButton
+                ? ''
+                : substr_replace( $editButton, $editor->getUrl($extensionPoint->getFilepath(),$extensionPoint->getLn()), 10, 0 );
 
             $docs = '';
             $docs .= '<div class="cheatsheet-docs-block">';
@@ -57,7 +67,7 @@ if (count($all)) {
 
             $docs .= '<table class="cheatsheet-docs-table"><colgroup><col width="180px" /><col width="*" /></colgroup>';
             $docs .= '<tfoot>';
-            $docs .= '<tr><th>' . rex_i18n::msg('cheatsheet_extension_point_register') . '</th><td><p><span class="text-muted">#' . str_replace('~', '&nbsp;', str_pad($extensionPoint->getLn(), 6, '~')) . '</span> ' . str_replace(\rex_path::src(), '', $extensionPoint->getFilepath()) . '</p><pre>' . $extensionPoint->getRegisteredPoint() . '</pre></td></tr>';
+            $docs .= '<tr><th>' . rex_i18n::msg('cheatsheet_extension_point_register') . '</th><td><p><span class="text-muted">#' . str_replace('~', '&nbsp;', str_pad($extensionPoint->getLn(), 6, '~')) . '</span> ' . str_replace(\rex_path::src(), '', $extensionPoint->getFilepath()) . $button . '</p><pre>' . $extensionPoint->getRegisteredPoint() . '</pre></td></tr>';
             $docs .= '</tfoot><tbody>';
             $docs .= '<tr><th>' . rex_i18n::msg('cheatsheet_extension_point_subject') . '</th><td>' . ($extensionPoint->getSubject() != '' ? '<pre>' . $extensionPoint->getSubject() . '</pre>' : '') . '</td></tr>';
             $docs .= '<tr><th>' . rex_i18n::msg('cheatsheet_extension_point_parameter') . '</th><td>' . ($extensionPoint->getParams() != '' ? '<pre>' . $extensionPoint->getParams() . '</pre>' : '') . '</td></tr>';

--- a/lib/ExtensionPoint/pages/docs.php
+++ b/lib/ExtensionPoint/pages/docs.php
@@ -52,7 +52,7 @@ if (count($all)) {
             $toc[] = '<a href="#' . $extensionPoint->getName() . '">' . $extensionPoint->getName() . '</a>';
             $button = '';
             if ($url = $editor->getUrl($extensionPoint->getFilepath(),$extensionPoint->getLn())) {
-               $button = ' <a href="'. $url .'" class="btn btn-info btn-xs"><i class="fa fa-edit"></i> '.$editor->getName().'</a>';
+               $button = ' <a href="'. $url .'" class="btn btn-info btn-xs"><i class="rex-icon rex-icon-view"></i> '.$editor->getName().'</a>';
             }
             $docs = '';
             $docs .= '<div class="cheatsheet-docs-block">';

--- a/lib/ExtensionPoint/pages/docs.php
+++ b/lib/ExtensionPoint/pages/docs.php
@@ -45,21 +45,15 @@ if (count($all)) {
         }
         $content .= '</nav>';
     } else {
-        
         $editor = rex_editor::factory();
-        $editButton = null === $editor->getName()
-            ? null
-            : ' <a href="" class="btn btn-info btn-xs"><i class="fa fa-edit"></i> '.$editor->getName().'</a>';
-
         $toc = [];
         $extensionPoints = ExtensionPoint::getByPackage($requestIndex);
         foreach ($extensionPoints as $extensionPoint) {
             $toc[] = '<a href="#' . $extensionPoint->getName() . '">' . $extensionPoint->getName() . '</a>';
-
-            $button = null === $editButton
-                ? ''
-                : substr_replace( $editButton, $editor->getUrl($extensionPoint->getFilepath(),$extensionPoint->getLn()), 10, 0 );
-
+            $button = '';
+            if ($url = $editor->getUrl($extensionPoint->getFilepath(),$extensionPoint->getLn())) {
+               $button = ' <a href="'. $url .'" class="btn btn-info btn-xs"><i class="fa fa-edit"></i> '.$editor->getName().'</a>';
+            }
             $docs = '';
             $docs .= '<div class="cheatsheet-docs-block">';
             $docs .= '<a name="' . $extensionPoint->getName() . '"></a>';


### PR DESCRIPTION
Hallo Thomas

ich hätte da einen Vorschlag

Seit einigen Versionen gibt es ja die Möglichkeit, einen Editor in der Systemkonfiguration zu aktivieren. Klappt bei mit (Atom) sehr gut. Darauf aufbauend könnte man doch die EP-Übersicht mit einem Button versehen, der den jeweiligen EP direkt in den Editor ruft. Dann kann man ohne lange zu suchen den EP im seinem Code-Umfeld ansehen. Beispiel:
<img width="1078" alt="grafik" src="https://user-images.githubusercontent.com/10065904/91049239-2ce70880-e61d-11ea-8b36-77e056280baa.png">

