### PR TITLE
EP-Klassen berücksichtigen

### DIFF
--- a/lib/ExtensionPoint/ExtensionPointParser.php
+++ b/lib/ExtensionPoint/ExtensionPointParser.php
@@ -13,17 +13,25 @@ namespace Cheatsheet\ExtensionPoint;
 
 use Cheatsheet\ParserAbstract;
 use Cheatsheet\Str;
-use SplFileInfo;
+use rex_file;
+use rex_path;
+
+use function count;
+use function strlen;
+
+use const DIRECTORY_SEPARATOR;
+use const PREG_OFFSET_CAPTURE;
+use const PREG_SET_ORDER;
 
 class ExtensionPointParser extends ParserAbstract
 {
-    const PATTERN = '
+    public const PATTERN = '
         @
         (?<complete>
             \s*
             rex_extension::registerPoint\(
                 \s*
-                new\s*\\\?rex_extension_point\(
+                new\s*\\\?rex_extension_point(_(?<class>[a-z0-9_]+))?\(
                     (?<params>.*?)
                 \)
                 \s*
@@ -33,57 +41,64 @@ class ExtensionPointParser extends ParserAbstract
         )
         @isx';
 
-
     public function parse()
     {
         $results = [];
 
-        /** @var SplFileInfo $file */
+        /** @var \SplFileInfo $file */
         foreach ($this->iterator as $file) {
             $filepath = $file->getPathname();
-            $content = \rex_file::get($filepath);
+            $content = rex_file::get($filepath);
 
-            $path = explode(DIRECTORY_SEPARATOR, str_replace(\rex_path::src(), '', $filepath));
+            $path = explode(DIRECTORY_SEPARATOR, str_replace(rex_path::src(), '', $filepath));
             $cacheFilename = 'core.cache';
-            if(isset($path[0]) && $path[0] === 'addons' && isset($path[2]) && $path[2] === 'plugins') {
+            if (isset($path[0]) && 'addons' == $path[0] && isset($path[2]) && 'plugins' == $path[2]) {
                 $cacheFilename = $path[1] . '.' . $path[3] . '.cache';
-            } elseif(isset($path[0]) && $path[0] === 'addons' && isset($path[1]) && $path[1] !== '') {
+            } elseif (isset($path[0]) && 'addons' == $path[0] && isset($path[1]) && '' != $path[1]) {
                 $cacheFilename = $path[1] . '.cache';
             }
 
             preg_match_all(self::PATTERN, $content, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
-            foreach ($matches as $match) {
-                $paramsAsString = $match['params'][0];
-                $paramsAsArray = Str::parseAsArray($paramsAsString);
+            if (count($matches)) {
+                // dump($matches);
+                foreach ($matches as $match) {
+                    $paramsAsString = $match['params'][0];
+                    $paramsAsArray = Str::parseAsArray($paramsAsString);
 
-                list($before) = str_split($content, $match['complete'][1]);
-                $lineNumber = strlen($before) - strlen(str_replace("\n", '', $before)) + 1;
+                    if (-1 < $match['class'][1]) {
+                        array_unshift($paramsAsArray, strtoupper($match['class'][0]));
+                        dump($paramsAsArray);
+                    }
 
-                $complete = trim($match['complete'][0], "\t\n\r\0\x0B");
-                $spaces = strspn($complete, " ");
-                if ($spaces <= 3) {
-                    $complete = trim($complete);
-                } else {
-                    $complete = implode("\n", array_map(function($line) use ($spaces) {
-                        return substr($line, $spaces);
-                    }, explode("\n", $complete)));
+                    [$before] = str_split($content, $match['complete'][1]);
+                    $lineNumber = strlen($before) - strlen(str_replace("\n", '', $before)) + 1;
+
+                    $complete = trim($match['complete'][0], "\t\n\r\0\x0B");
+                    $spaces = strspn($complete, ' ');
+                    if ($spaces <= 3) {
+                        $complete = trim($complete);
+                    } else {
+                        $complete = implode("\n", array_map(static function ($line) use ($spaces) {
+                            return substr($line, $spaces);
+                        }, explode("\n", $complete)));
+                    }
+
+                    $results[] = [
+                        'internal::cacheFilename' => $cacheFilename,
+                        'point' => $complete,
+                        'name' => trim($paramsAsArray[0], "'"),
+                        'subject' => ($paramsAsArray[1] ?? ''),
+                        'params' => ($paramsAsArray[2] ?? ''),
+                        'readonly' => (!isset($paramsAsArray[3]) || (isset($paramsAsArray[3]) && ('false' == $paramsAsArray[3] || '0' == $paramsAsArray[3])) ? 'false' : $paramsAsArray[3]),
+                        'filepath' => $filepath,
+                        'filename' => $file->getFilename(),
+                        'ln' => $lineNumber,
+                    ];
                 }
-
-                $results[] = [
-                    'internal::cacheFilename' => $cacheFilename,
-                    'point' => $complete,
-                    'name' => trim($paramsAsArray[0], "'"),
-                    'subject' => ($paramsAsArray[1] ?? ''),
-                    'params' => ($paramsAsArray[2] ?? ''),
-                    'readonly' => (!isset($paramsAsArray[3]) || (($paramsAsArray[3] === 'false' || $paramsAsArray[3] === '0')) ? 'false' : $paramsAsArray[3]),
-                    'filepath' => $filepath,
-                    'filename' => $file->getFilename(),
-                    'ln' => $lineNumber,
-                ];
             }
         }
 
-        if (count($results) > 0) {
+        if (count($results)) {
             usort($results, '\Cheatsheet\Arr::sortByName');
         }
 

--- a/lib/ExtensionPoint/ExtensionPointParser.php
+++ b/lib/ExtensionPoint/ExtensionPointParser.php
@@ -67,7 +67,6 @@ class ExtensionPointParser extends ParserAbstract
 
                     if (-1 < $match['class'][1]) {
                         array_unshift($paramsAsArray, strtoupper($match['class'][0]));
-                        dump($paramsAsArray);
                     }
 
                     [$before] = str_split($content, $match['complete'][1]);


### PR DESCRIPTION
EP-Klassen wie `rex_extension_point_art_content_updated` werden nun auch vom Parser erkannt.

Die Änderungen betreffen

1. den Regex-Pattern: aus `new\s*\\\?rex_extension_point?\(` wurde `new\s*\\\?rex_extension_point(_(?<class>[a-z0-9_]+))?\(`. Wenn also hinter `rex_extension_point` ein `_ep_name` steht wird der als `$matches['class']` ausgewiesen ohne `_`. 
2. Der ermittelte Name (`$matches['class'][0]`) wird dem `$paramsAsArray` als erstes Element (=EP-Name, Großbuchstaben) vorangestellt, damit die erwarteten vier Parameter wie immer vorliegen (`array_unshift($paramsAsArray, strtoupper($match['class'][0]));`).

Die restlichen Änderungen sind entstanden, als ich den PHP_CS_FIxer drüberlaufen ließ.